### PR TITLE
Update spinbox na ga_naar() vanuit code

### DIFF
--- a/hoofd_scherm.cpp
+++ b/hoofd_scherm.cpp
@@ -42,6 +42,7 @@ hoofd_scherm::~hoofd_scherm()
 void hoofd_scherm::ga_naar(const kamer_soort kamer)
 {
   m_kamer = kamer;
+  this->ui->spinBox->setValue(static_cast<int>(kamer));
   laat_kamer_zien();
 }
 


### PR DESCRIPTION
Bij deze verandering:

    void kamer_jesper::on_knop_deur_clicked()
    {
        this->m_hoofd_scherm->ga_naar(kamer_soort::jasper);
    }

Wissel ik wel van kamer, maar update de spinbox niet mee. Na deze change wel.